### PR TITLE
Class redesign: change base class from abstract to concrete

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -8,7 +8,7 @@
 #' regularization path using warm starts for successive iterations.
 #'
 #' @param x features
-#' @param y response
+#' @param response the model family
 #' @param is_sparse whether x is sparse or not
 #' @param control a list of control parameters
 #'

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -20,13 +20,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // SgdnetSparse
-Rcpp::List SgdnetSparse(const Eigen::SparseMatrix<double>& x, std::vector<double> y, const Rcpp::List& control);
+Rcpp::List SgdnetSparse(const Eigen::SparseMatrix<double>& x, const std::vector<double>& y, const Rcpp::List& control);
 RcppExport SEXP _sgdnet_SgdnetSparse(SEXP xSEXP, SEXP ySEXP, SEXP controlSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::vector<double> >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type control(controlSEXP);
     rcpp_result_gen = Rcpp::wrap(SgdnetSparse(x, y, control));
     return rcpp_result_gen;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,25 +7,25 @@
 using namespace Rcpp;
 
 // SgdnetDense
-Rcpp::List SgdnetDense(Eigen::MatrixXd x, std::vector<double> y, const Rcpp::List& control);
+Rcpp::List SgdnetDense(const Eigen::MatrixXd& x, const std::vector<double>& y, const Rcpp::List& control);
 RcppExport SEXP _sgdnet_SgdnetDense(SEXP xSEXP, SEXP ySEXP, SEXP controlSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Eigen::MatrixXd >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::vector<double> >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type control(controlSEXP);
     rcpp_result_gen = Rcpp::wrap(SgdnetDense(x, y, control));
     return rcpp_result_gen;
 END_RCPP
 }
 // SgdnetSparse
-Rcpp::List SgdnetSparse(Eigen::SparseMatrix<double> x, std::vector<double> y, const Rcpp::List& control);
+Rcpp::List SgdnetSparse(const Eigen::SparseMatrix<double>& x, std::vector<double> y, const Rcpp::List& control);
 RcppExport SEXP _sgdnet_SgdnetSparse(SEXP xSEXP, SEXP ySEXP, SEXP controlSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type x(xSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type y(ySEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type control(controlSEXP);
     rcpp_result_gen = Rcpp::wrap(SgdnetSparse(x, y, control));

--- a/src/families.h
+++ b/src/families.h
@@ -39,19 +39,19 @@ public:
     y_mat.setZero(n_samples, n_classes);
   };
 
-  double Loss(const unsigned i);
+  double Loss(const unsigned i) noexcept;
 
-  void Gradient(const unsigned i);
+  void Gradient(const unsigned i) noexcept;
 
-  void PreprocessResponse();
+  void PreprocessResponse() noexcept;
 
-  double NullDeviance(const bool fit_intercept);
+  double NullDeviance(const bool fit_intercept) noexcept;
 
   void Predict(const std::vector<double>& w,
                const double               wscale,
                const unsigned             n_features,
                const unsigned             s_ind,
-               const Eigen::MatrixXd&     x);
+               const Eigen::MatrixXd&     x) noexcept;
 
   void Predict(const std::vector<double>&         w,
                const double                       wscale,
@@ -97,7 +97,7 @@ public:
            const unsigned             n_classes)
            : Family(y, n_samples, n_classes, 1.0) {}
 
-  void PreprocessResponse() {
+  void PreprocessResponse() noexcept {
     y_center[0] = Mean(y);
     y_scale[0] = StandardDeviation(y, y_center[0]);
     y_mat_scale[0] = y_scale[0];
@@ -115,7 +115,7 @@ public:
                const double               wscale,
                const unsigned             n_features,
                const unsigned             s_ind,
-               const Eigen::MatrixXd&     x) {
+               const Eigen::MatrixXd&     x) noexcept {
 
     double inner_product = 0.0;
     for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
@@ -128,7 +128,7 @@ public:
                const double                       wscale,
                const unsigned                     n_features,
                const unsigned                     s_ind,
-               const Eigen::SparseMatrix<double>& x) {
+               const Eigen::SparseMatrix<double>& x) noexcept {
 
     double inner_product = 0.0;
     for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
@@ -137,23 +137,23 @@ public:
     prediction = wscale*inner_product + intercept;
   }
 
-  double Loss(const unsigned i) {
+  double Loss(const unsigned i) noexcept {
     return 0.5*(prediction - y[i])*(prediction - y[i]);
   }
 
-  void Gradient(const unsigned i) {
+  void Gradient(const unsigned i) noexcept {
     gradient = prediction - y[i];
     gradient_change = gradient - gradient_memory[i];
     gradient_memory[i] = gradient;
   }
 
-  void FitIntercept(const double gamma, const double intercept_decay) {
+  void FitIntercept(const double gamma, const double intercept_decay) noexcept {
     gradient_sum_intercept += gradient_change/n_samples;
     intercept -=
       gamma*gradient_sum_intercept*intercept_decay + gradient_change/n_samples;
   }
 
-  double NullDeviance(const bool fit_intercept) {
+  double NullDeviance(const bool fit_intercept) noexcept {
     prediction = Mean(y);
 
     double loss = 0.0;
@@ -191,7 +191,7 @@ public:
                const double               wscale,
                const unsigned             n_features,
                const unsigned             s_ind,
-               const Eigen::MatrixXd&     x) {
+               const Eigen::MatrixXd&     x) noexcept {
 
     double inner_product = 0.0;
     for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
@@ -204,7 +204,7 @@ public:
                const double                       wscale,
                const unsigned                     n_features,
                const unsigned                     s_ind,
-               const Eigen::SparseMatrix<double>& x) {
+               const Eigen::SparseMatrix<double>& x) noexcept {
 
     double inner_product = 0.0;
     for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
@@ -213,7 +213,7 @@ public:
     prediction = wscale*inner_product + intercept;
   }
 
-  double Link(double y) {
+  double Link(double y) noexcept {
     // TODO(jolars): let the user set this.
     double pmin = 1e-9;
     double pmax = 1.0 - pmin;
@@ -222,23 +222,23 @@ public:
     return std::log(z / (1.0 - z));
   }
 
-  double Loss(const unsigned i) {
+  double Loss(const unsigned i) noexcept {
     return std::log(1.0 + std::exp(prediction)) - y[i]*prediction;
   }
 
-  void Gradient(const unsigned i) {
+  void Gradient(const unsigned i) noexcept {
     gradient = 1.0 - y[i] - 1.0/(1.0 + std::exp(prediction));
     gradient_change = gradient - gradient_memory[i];
     gradient_memory[i] = gradient;
   }
 
-  void FitIntercept(const double gamma, const double intercept_decay) {
+  void FitIntercept(const double gamma, const double intercept_decay) noexcept {
     gradient_sum_intercept += gradient_change/n_samples;
     intercept -=
       gamma*gradient_sum_intercept*intercept_decay + gradient_change/n_samples;
   }
 
-  double NullDeviance(const bool fit_intercept) {
+  double NullDeviance(const bool fit_intercept) noexcept {
     prediction = fit_intercept ? Link(Mean(y)) : 0.0;
 
     double loss = 0.0;
@@ -269,7 +269,7 @@ public:
     intercept.resize(n_classes);
   }
 
-  void PreprocessResponse() {
+  void PreprocessResponse() noexcept {
     std::vector<double> y_mu(n_classes);
     std::vector<double> y_var(n_classes);
 
@@ -300,7 +300,7 @@ public:
                const double               wscale,
                const unsigned             n_features,
                const unsigned             s_ind,
-               const Eigen::MatrixXd&     x) {
+               const Eigen::MatrixXd&     x) noexcept {
 
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
       double inner_product = 0.0;
@@ -315,7 +315,7 @@ public:
                const double                       wscale,
                const unsigned                     n_features,
                const unsigned                     s_ind,
-               const Eigen::SparseMatrix<double>& x) {
+               const Eigen::SparseMatrix<double>& x) noexcept {
 
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
       double inner_product = 0.0;
@@ -326,12 +326,12 @@ public:
     }
   }
 
-  double Loss(const unsigned i) {
+  double Loss(const unsigned i) noexcept {
     auto c = static_cast<unsigned>(y[i] + 0.5);
     return LogSumExp(prediction) - prediction[c];
   }
 
-  void Gradient(const unsigned i) {
+  void Gradient(const unsigned i) noexcept {
 
     auto lse = LogSumExp(prediction);
     auto c = static_cast<unsigned>(y[i] + 0.5);
@@ -347,7 +347,7 @@ public:
     }
   }
 
-  void FitIntercept(const double gamma, const double intercept_decay) {
+  void FitIntercept(const double gamma, const double intercept_decay) noexcept {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
       gradient_sum_intercept[c_ind] += gradient_change[c_ind]/n_samples;
       intercept[c_ind] -= gamma*gradient_sum_intercept[c_ind]*intercept_decay
@@ -355,7 +355,7 @@ public:
     }
   }
 
-  double NullDeviance(const bool fit_intercept) {
+  double NullDeviance(const bool fit_intercept) noexcept {
     if (fit_intercept)
       prediction = Proportions(y, n_classes);
     else

--- a/src/families.h
+++ b/src/families.h
@@ -20,7 +20,6 @@
 #include <memory>
 #include "math.h"
 #include "utils.h"
-
 namespace sgdnet {
 
 class Family {
@@ -40,20 +39,17 @@ public:
     y_mat_scale.resize(n_classes, 1.0);
   };
 
-  virtual double Link(const unsigned i) = 0;
+  double Link(const unsigned i);
+  double Loss(const double prediction, const unsigned i);
+  double Loss(const std::vector<double>& prediction, const unsigned i);
 
-  virtual double Loss(const double prediction, const unsigned i) = 0;
+  void Gradient(std::vector<double>&       g_i,
+                const std::vector<double>& prediction,
+                const unsigned             i);
 
-  virtual double Loss(const std::vector<double>& prediction,
-                      const unsigned i) = 0;
+  void PreprocessResponse();
 
-  virtual void Gradient(std::vector<double>&       g_i,
-                        const std::vector<double>& prediction,
-                        const unsigned             i) = 0;
-
-  virtual void PreprocessResponse() = 0;
-
-  virtual double NullDeviance(const bool fit_intercept) = 0;
+  double NullDeviance(const bool fit_intercept);
 
   std::vector<double> StepSize(const double               max_squared_sum,
                                const std::vector<double>& alpha_scaled,
@@ -77,9 +73,9 @@ public:
   std::vector<double> y_scale;
   Eigen::MatrixXd y_mat;
   std::vector<double> y_mat_scale;
-  unsigned n_samples;
-  unsigned n_classes;
-  unsigned n_targets;
+  std::size_t n_samples;
+  std::size_t n_classes;
+  std::size_t n_targets;
   double null_deviance = 0.0;
   double L_scaling;
   double lambda_scaling = 1.0;

--- a/src/families.h
+++ b/src/families.h
@@ -25,31 +25,39 @@ namespace sgdnet {
 class Family {
 public:
   Family(const std::vector<double>& y,
-         const unsigned n_samples,
-         const unsigned n_classes,
-         const double L_scaling)
+         const unsigned             n_samples,
+         const unsigned             n_classes,
+         const double               L_scaling)
          : y(y),
            n_samples(n_samples),
            n_classes(n_classes),
-           L_scaling(L_scaling) {
-    // Initialize scaling and centering parameters for the response
-    y_center.resize(n_classes, 0.0);
-    y_scale.resize(n_classes, 1.0);
+           L_scaling(L_scaling),
+           y_center(n_classes),
+           y_scale(n_classes, 1.0),
+           y_mat_scale(n_classes, 1.0),
+           gradient_memory(n_classes*n_samples, 0.0) {
     y_mat.setZero(n_samples, n_classes);
-    y_mat_scale.resize(n_classes, 1.0);
   };
 
-  double Link(const unsigned i);
-  double Loss(const double prediction, const unsigned i);
-  double Loss(const std::vector<double>& prediction, const unsigned i);
+  double Loss(const unsigned i);
 
-  void Gradient(std::vector<double>&       g_i,
-                const std::vector<double>& prediction,
-                const unsigned             i);
+  void Gradient(const unsigned i);
 
   void PreprocessResponse();
 
   double NullDeviance(const bool fit_intercept);
+
+  void Predict(const std::vector<double>& w,
+               const double               wscale,
+               const unsigned             n_features,
+               const unsigned             s_ind,
+               const Eigen::MatrixXd&     x);
+
+  void Predict(const std::vector<double>&         w,
+               const double                       wscale,
+               const unsigned                     n_features,
+               const unsigned                     s_ind,
+               const Eigen::SparseMatrix<double>& x);
 
   std::vector<double> StepSize(const double               max_squared_sum,
                                const std::vector<double>& alpha_scaled,
@@ -73,9 +81,10 @@ public:
   std::vector<double> y_scale;
   Eigen::MatrixXd y_mat;
   std::vector<double> y_mat_scale;
-  std::size_t n_samples;
-  std::size_t n_classes;
-  std::size_t n_targets;
+  std::vector<double> gradient_memory;
+  unsigned n_samples;
+  unsigned n_classes;
+  unsigned n_targets;
   double null_deviance = 0.0;
   double L_scaling;
   double lambda_scaling = 1.0;
@@ -84,8 +93,8 @@ public:
 class Gaussian : public Family {
 public:
   Gaussian(const std::vector<double>& y,
-           const unsigned n_samples,
-           const unsigned n_classes)
+           const unsigned             n_samples,
+           const unsigned             n_classes)
            : Family(y, n_samples, n_classes, 1.0) {}
 
   void PreprocessResponse() {
@@ -93,7 +102,7 @@ public:
     y_scale[0] = StandardDeviation(y, y_center[0]);
     y_mat_scale[0] = y_scale[0];
 
-    for (std::size_t i = 0; i < n_samples; ++i) {
+    for (unsigned i = 0; i < n_samples; ++i) {
       y[i] -= y_center[0];
       y[i] /= y_scale[0];
       y_mat(i, 0) = y[i];
@@ -102,48 +111,106 @@ public:
     lambda_scaling = y_scale[0];
   }
 
-  double Link(const unsigned i) { return y[i]; }
+  void Predict(const std::vector<double>& w,
+               const double               wscale,
+               const unsigned             n_features,
+               const unsigned             s_ind,
+               const Eigen::MatrixXd&     x) {
 
-  double Loss(const double prediction, const unsigned i) {
+    double inner_product = 0.0;
+    for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
+      inner_product += x(f_ind, s_ind) * w[f_ind];
+
+    prediction = wscale*inner_product + intercept;
+  }
+
+  void Predict(const std::vector<double>&         w,
+               const double                       wscale,
+               const unsigned                     n_features,
+               const unsigned                     s_ind,
+               const Eigen::SparseMatrix<double>& x) {
+
+    double inner_product = 0.0;
+    for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
+      inner_product += it.value() * w[it.index()];
+
+    prediction = wscale*inner_product + intercept;
+  }
+
+  double Loss(const unsigned i) {
     return 0.5*(prediction - y[i])*(prediction - y[i]);
   }
 
-  double Loss(const std::vector<double>& prediction, const unsigned i) {
-    return Loss(prediction[0], i);
+  void Gradient(const unsigned i) {
+    gradient = prediction - y[i];
+    gradient_change = gradient - gradient_memory[i];
+    gradient_memory[i] = gradient;
   }
 
-  void Gradient(std::vector<double>&       g_i,
-                const std::vector<double>& prediction,
-                const unsigned             i) {
-    g_i[0] = prediction[0] - y[i];
+  void FitIntercept(const double gamma, const double intercept_decay) {
+    gradient_sum_intercept += gradient_change/n_samples;
+    intercept -=
+      gamma*gradient_sum_intercept*intercept_decay + gradient_change/n_samples;
   }
 
   double NullDeviance(const bool fit_intercept) {
-    auto y_mu = Mean(y);
+    prediction = Mean(y);
 
     double loss = 0.0;
     for (unsigned i = 0; i < y.size(); ++i)
-      loss += Loss(y_mu, i);
+      loss += Loss(i);
 
     return 2.0 * loss;
   }
+
+  double gradient = 0.0;
+  double gradient_change = 0.0;
+  double gradient_sum_intercept = 0.0;
+  double prediction = 0.0;
+  double intercept = 0.0;
 };
 
 class Binomial : public Family {
 public:
   Binomial(const std::vector<double>& y,
-           const unsigned n_samples,
-           const unsigned n_classes)
+           const unsigned             n_samples,
+           const unsigned             n_classes)
            : Family(y, n_samples, n_classes, 0.25) {}
 
   void PreprocessResponse() {
     auto y_mu = Mean(y);
     auto y_sd = StandardDeviation(y, y_mu);
 
-    for (std::size_t i = 0; i < n_samples; ++i)
+    for (unsigned i = 0; i < n_samples; ++i)
       y_mat(i, 0) = (y[i] - y_mu)/y_sd;
 
     y_mat_scale[0] = y_sd;
+  }
+
+  void Predict(const std::vector<double>& w,
+               const double               wscale,
+               const unsigned             n_features,
+               const unsigned             s_ind,
+               const Eigen::MatrixXd&     x) {
+
+    double inner_product = 0.0;
+    for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
+      inner_product += x(f_ind, s_ind) * w[f_ind];
+
+    prediction = wscale*inner_product + intercept;
+  }
+
+  void Predict(const std::vector<double>&         w,
+               const double                       wscale,
+               const unsigned                     n_features,
+               const unsigned                     s_ind,
+               const Eigen::SparseMatrix<double>& x) {
+
+    double inner_product = 0.0;
+    for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
+      inner_product += it.value() * w[it.index()];
+
+    prediction = wscale*inner_product + intercept;
   }
 
   double Link(double y) {
@@ -155,41 +222,52 @@ public:
     return std::log(z / (1.0 - z));
   }
 
-  double Link(const unsigned i) {
-    return Link(y[i]);
-  }
-
-  double Loss(const double prediction, const unsigned i) {
+  double Loss(const unsigned i) {
     return std::log(1.0 + std::exp(prediction)) - y[i]*prediction;
   }
 
-  double Loss(const std::vector<double>& prediction, const unsigned i) {
-    return Loss(prediction[0], i);
+  void Gradient(const unsigned i) {
+    gradient = 1.0 - y[i] - 1.0/(1.0 + std::exp(prediction));
+    gradient_change = gradient - gradient_memory[i];
+    gradient_memory[i] = gradient;
   }
 
-  void Gradient(std::vector<double>&       g_i,
-                const std::vector<double>& prediction,
-                const unsigned             i) {
-    g_i[0] = 1.0 - y[i] - 1.0/(1.0 + std::exp(prediction[0]));
+  void FitIntercept(const double gamma, const double intercept_decay) {
+    gradient_sum_intercept += gradient_change/n_samples;
+    intercept -=
+      gamma*gradient_sum_intercept*intercept_decay + gradient_change/n_samples;
   }
 
   double NullDeviance(const bool fit_intercept) {
-    double pred = fit_intercept ? Link(Mean(y)) : 0.0;
+    prediction = fit_intercept ? Link(Mean(y)) : 0.0;
 
     double loss = 0.0;
     for (unsigned i = 0; i < n_samples; ++i)
-      loss += Loss(pred, i);
+      loss += Loss(i);
 
     return 2.0 * loss;
   }
+
+  double gradient = 0.0;
+  double gradient_change = 0.0;
+  double gradient_sum_intercept = 0.0;
+  double prediction = 0.0;
+  double intercept = 0.0;
 };
 
 class Multinomial : public Family {
 public:
   Multinomial(const std::vector<double>& y,
-              const unsigned n_samples,
-              const unsigned n_classes)
-              : Family(y, n_samples, n_classes, 0.5) {}
+              const unsigned             n_samples,
+              const unsigned             n_classes)
+              : Family(y, n_samples, n_classes, 0.5) {
+
+    gradient.resize(n_classes);
+    gradient_change.resize(n_classes);
+    gradient_sum_intercept.resize(n_classes);
+    prediction.resize(n_classes);
+    intercept.resize(n_classes);
+  }
 
   void PreprocessResponse() {
     std::vector<double> y_mu(n_classes);
@@ -218,65 +296,97 @@ public:
     }
   }
 
-  double Link(const unsigned i) {
-    return std::log(y[i] / (1.0 - y[i]));
-  }
-
-  double Loss(const double prediction, const unsigned i) {
-    // Not reasonable for multinomial model
-    return 0.0;
-  }
-
-  double Loss(const std::vector<double>& prediction, const unsigned i) {
-
-    unsigned y_class = std::round(y[i]);
-
-    return LogSumExp(prediction) - prediction[y_class];
-  }
-
-  void Gradient(std::vector<double>&       g_i,
-                const std::vector<double>& prediction,
-                const unsigned             i) {
-
-    auto lse = LogSumExp(prediction);
-    unsigned y_i = static_cast<unsigned>(y[i] + 0.5);
+  void Predict(const std::vector<double>& w,
+               const double               wscale,
+               const unsigned             n_features,
+               const unsigned             s_ind,
+               const Eigen::MatrixXd&     x) {
 
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
-      g_i[c_ind] = std::exp(prediction[c_ind] - lse);
+      double inner_product = 0.0;
+      for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
+        inner_product += x(f_ind, s_ind) * w[f_ind*n_classes + c_ind];
 
-      if (c_ind == y_i)
-        g_i[c_ind] -= 1.0;
+      prediction[c_ind] = wscale*inner_product + intercept[c_ind];
+    }
+  }
+
+  void Predict(const std::vector<double>&         w,
+               const double                       wscale,
+               const unsigned                     n_features,
+               const unsigned                     s_ind,
+               const Eigen::SparseMatrix<double>& x) {
+
+    for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
+      double inner_product = 0.0;
+      for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
+        inner_product += it.value() * w[it.index()*n_classes + c_ind];
+
+      prediction[c_ind] = wscale*inner_product + intercept[c_ind];
+    }
+  }
+
+  double Loss(const unsigned i) {
+    auto c = static_cast<unsigned>(y[i] + 0.5);
+    return LogSumExp(prediction) - prediction[c];
+  }
+
+  void Gradient(const unsigned i) {
+
+    auto lse = LogSumExp(prediction);
+    auto c = static_cast<unsigned>(y[i] + 0.5);
+
+    for (unsigned j = 0; j < n_classes; ++j) {
+      gradient[j] = std::exp(prediction[j] - lse);
+
+      if (j == c)
+        gradient[j] -= 1.0;
+
+      gradient_change[j] = gradient[j] - gradient_memory[i*n_classes + j];
+      gradient_memory[i*n_classes + j] = gradient[j];
+    }
+  }
+
+  void FitIntercept(const double gamma, const double intercept_decay) {
+    for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
+      gradient_sum_intercept[c_ind] += gradient_change[c_ind]/n_samples;
+      intercept[c_ind] -= gamma*gradient_sum_intercept[c_ind]*intercept_decay
+        + gradient_change[c_ind]/n_samples;
     }
   }
 
   double NullDeviance(const bool fit_intercept) {
-    std::vector<double> pred;
-
     if (fit_intercept)
-      pred = Proportions(y, n_classes);
+      prediction = Proportions(y, n_classes);
     else
-      pred.resize(n_classes, 1.0/n_classes);
+      prediction.assign(n_classes, 1.0/n_classes);
 
-    double pred_sum_avg = 0.0;
+    double prediction_sum_avg = 0.0;
 
-    for (auto& pred_i : pred) {
-      pred_i = std::log(pred_i);
-      pred_sum_avg += pred_i/n_classes;
+    for (auto& prediction_i : prediction) {
+      prediction_i = std::log(prediction_i);
+      prediction_sum_avg += prediction_i/n_classes;
     }
 
-    for (auto& pred_i : pred)
-      pred_i -= pred_sum_avg;
+    for (auto& prediction_i : prediction)
+      prediction_i -= prediction_sum_avg;
 
     double loss = 0.0;
-    double lse = LogSumExp(pred);
+    double lse = LogSumExp(prediction);
 
-    for (unsigned i = 0; i < n_samples; ++i) {
-      unsigned y_class = static_cast<unsigned>(y[i] + 0.5);
-      loss += lse - pred[y_class];
+    for (const auto y_i : y) {
+      auto c = static_cast<unsigned>(y_i + 0.5);
+      loss += lse - prediction[c];
     }
 
     return 2.0 * loss;
   }
+
+  std::vector<double> gradient;
+  std::vector<double> gradient_change;
+  std::vector<double> gradient_sum_intercept;
+  std::vector<double> prediction;
+  std::vector<double> intercept;
 };
 
 } // namespace sgdnet

--- a/src/prox.h
+++ b/src/prox.h
@@ -30,7 +30,7 @@ namespace sgdnet {
 //' @keywords internal
 class Prox {
 public:
-  virtual double Evaluate(const double x, const double shrinkage) = 0;
+  double operator()(const double x, const double shrinkage) const;
 };
 
 //' Soft thresholding operator for L1-regularization
@@ -43,11 +43,11 @@ public:
 //' @keywords internal
 class SoftThreshold : public Prox {
 public:
-  double Evaluate(const double x, const double shrinkage) {
+  double operator()(const double x, const double shrinkage) const {
     return std::max(x - shrinkage, 0.0) - std::max(-x - shrinkage, 0.0);
   }
 };
 
-} // namespace sgdnet
+}
 
 #endif // SGDNET_PROX_

--- a/src/saga.h
+++ b/src/saga.h
@@ -134,18 +134,19 @@ inline void LaggedUpdate(const unsigned                     k,
 //' @param prox pointer to the proximal operator
 //'
 //' @return Updates weights and lag.
-inline void LaggedProjection(const unsigned                       k,
-                             std::vector<double>&                 w,
-                             const unsigned                       n_features,
-                             const unsigned                       n_classes,
-                             const std::vector<double>&           g_sum,
-                             std::vector<unsigned>&               lag,
-                             const Eigen::MatrixXd&               x,
-                             const unsigned                       s_ind,
-                             const std::vector<double>&           lag_scaling,
-                             const double                         prox_scaling,
-                             const double                         grad_scaling,
-                             const std::unique_ptr<sgdnet::Prox>& prox) {
+template <typename Prox>
+inline void LaggedProjection(const unsigned             k,
+                             std::vector<double>&       w,
+                             const unsigned             n_features,
+                             const unsigned             n_classes,
+                             const std::vector<double>& g_sum,
+                             std::vector<unsigned>&     lag,
+                             const Eigen::MatrixXd&     x,
+                             const unsigned             s_ind,
+                             const std::vector<double>& lag_scaling,
+                             const double               prox_scaling,
+                             const double               grad_scaling,
+                             const Prox&                prox) {
 
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
@@ -158,23 +159,24 @@ inline void LaggedProjection(const unsigned                       k,
 
       lag[idx] = k;
       w[idx] += grad_scaling*lag_scaling[lagged_amount]*g_sum[idx];
-      w[idx] = prox->Evaluate(w[idx], prox_scaling*lag_scaling[lagged_amount]);
+      w[idx] = prox(w[idx], prox_scaling*lag_scaling[lagged_amount]);
     }
   }
 }
 
-inline void LaggedProjection(const unsigned                       k,
-                             std::vector<double>&                 w,
-                             const unsigned                       n_features,
-                             const unsigned                       n_classes,
-                             const std::vector<double>&           g_sum,
-                             std::vector<unsigned>&               lag,
-                             const Eigen::SparseMatrix<double>&   x,
-                             const unsigned                       s_ind,
-                             const std::vector<double>&           lag_scaling,
-                             const double                         prox_scaling,
-                             const double                         grad_scaling,
-                             const std::unique_ptr<sgdnet::Prox>& prox)  {
+template <typename Prox>
+inline void LaggedProjection(const unsigned                     k,
+                             std::vector<double>&               w,
+                             const unsigned                     n_features,
+                             const unsigned                     n_classes,
+                             const std::vector<double>&         g_sum,
+                             std::vector<unsigned>&             lag,
+                             const Eigen::SparseMatrix<double>& x,
+                             const unsigned                     s_ind,
+                             const std::vector<double>&         lag_scaling,
+                             const double                       prox_scaling,
+                             const double                       grad_scaling,
+                             const Prox&                        prox)  {
 
   for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
@@ -187,7 +189,7 @@ inline void LaggedProjection(const unsigned                       k,
 
       lag[idx] = k;
       w[idx] += grad_scaling*lag_scaling[lagged_amount]*g_sum[idx];
-      w[idx] = prox->Evaluate(w[idx], prox_scaling*lag_scaling[lagged_amount]);
+      w[idx] = prox(w[idx], prox_scaling*lag_scaling[lagged_amount]);
     }
   }
 }
@@ -243,18 +245,19 @@ inline void AddWeighted(std::vector<double>&               a,
 //' @param prox pointer to the proximal operator
 //'
 //' @return Unlags the coefficients by adding the lagged updates.
-inline void Reset(const unsigned                       k,
-                  std::vector<double>&                 w,
-                  std::vector<double>&                 g_sum,
-                  std::vector<double>&                 lag_scaling,
-                  std::vector<unsigned>&               lag,
-                  const unsigned                       n_features,
-                  const unsigned                       n_classes,
-                  const double                         wscale,
-                  const double                         prox_scaling,
-                  const double                         grad_scaling,
-                  const bool                           nontrivial_prox,
-                  const std::unique_ptr<sgdnet::Prox>& prox) {
+template <typename Prox>
+inline void Reset(const unsigned         k,
+                  std::vector<double>&   w,
+                  std::vector<double>&   g_sum,
+                  std::vector<double>&   lag_scaling,
+                  std::vector<unsigned>& lag,
+                  const unsigned         n_features,
+                  const unsigned         n_classes,
+                  const double           wscale,
+                  const double           prox_scaling,
+                  const double           grad_scaling,
+                  const bool             nontrivial_prox,
+                  const Prox&            prox) {
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
       unsigned idx = f_ind*n_classes + c_ind;
@@ -264,8 +267,7 @@ inline void Reset(const unsigned                       k,
       w[idx] += lag_scaling[lagged_amount]*grad_scaling*g_sum[idx];
 
       if (nontrivial_prox)
-        w[idx] =
-          prox->Evaluate(w[idx], lag_scaling[lagged_amount]*prox_scaling);
+        w[idx] = prox(w[idx], lag_scaling[lagged_amount]*prox_scaling);
 
       // Rescale weights
       w[idx] *= wscale;
@@ -310,29 +312,29 @@ inline void Reset(const unsigned                       k,
 //'
 //' @return Updates `w`, `intercept`, `g_sum`, `g_sum_intercept`, `g`,
 //'   `n_iter`, `return_codes`, and possibly `losses`.
-template <typename T>
-void Saga(const T&                               x,
-          const bool                             fit_intercept,
-          const double                           intercept_decay,
-          std::vector<double>&                   intercept,
-          std::vector<double>&                   w,
-          const std::unique_ptr<sgdnet::Family>& family,
-          const std::unique_ptr<sgdnet::Prox>&   prox,
-          const double                           gamma,
-          const double                           alpha,
-          const double                           beta,
-          std::vector<double>&                   g_sum,
-          std::vector<double>&                   g_sum_intercept,
-          std::vector<double>&                   g,
-          const unsigned                         n_samples,
-          const unsigned                         n_features,
-          const unsigned                         n_classes,
-          const unsigned                         max_iter,
-          const double                           tol,
-          unsigned&                              n_iter,
-          std::vector<unsigned>&                 return_codes,
-          std::vector<double>&                   losses,
-          const bool                             debug) {
+template <typename Features, typename Family, typename Prox>
+void Saga(const Features&        x,
+          const bool             fit_intercept,
+          const double           intercept_decay,
+          std::vector<double>&   intercept,
+          std::vector<double>&   w,
+          Family&                family,
+          Prox&                  prox,
+          const double           gamma,
+          const double           alpha,
+          const double           beta,
+          std::vector<double>&   g_sum,
+          std::vector<double>&   g_sum_intercept,
+          std::vector<double>&   g,
+          const unsigned         n_samples,
+          const unsigned         n_features,
+          const unsigned         n_classes,
+          const unsigned         max_iter,
+          const double           tol,
+          unsigned&              n_iter,
+          std::vector<unsigned>& return_codes,
+          std::vector<double>&   losses,
+          const bool             debug) {
 
   using namespace std;
 
@@ -412,7 +414,7 @@ void Saga(const T&                               x,
                     x,
                     intercept);
 
-      family->Gradient(g_i, prediction, s_ind);
+      family.Gradient(g_i, prediction, s_ind);
 
       for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
         unsigned idx = s_ind*n_classes + c_ind;

--- a/src/saga.h
+++ b/src/saga.h
@@ -76,7 +76,7 @@ inline void LaggedUpdate(const unsigned             k,
                          const Eigen::MatrixXd&     x,
                          const unsigned             s_ind,
                          const std::vector<double>& lag_scaling,
-                         const double               grad_scaling) {
+                         const double               grad_scaling) noexcept {
 
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
@@ -102,7 +102,7 @@ inline void LaggedUpdate(const unsigned                     k,
                          const Eigen::SparseMatrix<double>& x,
                          const unsigned                     s_ind,
                          const std::vector<double>&         lag_scaling,
-                         const double                       grad_scaling) {
+                         const double                       grad_scaling) noexcept {
 
   for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
@@ -146,7 +146,7 @@ inline void LaggedProjection(const unsigned             k,
                              const std::vector<double>& lag_scaling,
                              const double               prox_scaling,
                              const double               grad_scaling,
-                             const Prox&                prox) {
+                             const Prox&                prox) noexcept {
 
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
@@ -176,7 +176,7 @@ inline void LaggedProjection(const unsigned                     k,
                              const std::vector<double>&         lag_scaling,
                              const double                       prox_scaling,
                              const double                       grad_scaling,
-                             const Prox&                        prox)  {
+                             const Prox&                        prox) noexcept {
 
   for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
@@ -209,7 +209,7 @@ inline void AddWeighted(std::vector<double>&       a,
                         const unsigned             n_features,
                         const unsigned             n_classes,
                         const double               g_change,
-                        const double               scaling)  {
+                        const double               scaling) noexcept {
 
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
       a[f_ind] += g_change * scaling * x(f_ind, s_ind);
@@ -221,7 +221,7 @@ inline void AddWeighted(std::vector<double>&               a,
                         const unsigned                     n_features,
                         const unsigned                     n_classes,
                         const double                       g_change,
-                        const double                       scaling) {
+                        const double                       scaling) noexcept {
 
   for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
       a[it.index()] += g_change * scaling * it.value();
@@ -233,7 +233,7 @@ inline void AddWeighted(std::vector<double>&       a,
                         const unsigned             n_features,
                         const unsigned             n_classes,
                         const std::vector<double>& g_change,
-                        const double               scaling)  {
+                        const double               scaling) noexcept {
 
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind)
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind)
@@ -246,7 +246,7 @@ inline void AddWeighted(std::vector<double>&               a,
                         const unsigned                     n_features,
                         const unsigned                     n_classes,
                         const std::vector<double>&         g_change,
-                        const double                       scaling) {
+                        const double                       scaling) noexcept {
 
   for (Eigen::SparseMatrix<double>::InnerIterator it(x, s_ind); it; ++it)
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind)
@@ -281,7 +281,7 @@ inline void Reset(const unsigned         k,
                   const double           prox_scaling,
                   const double           grad_scaling,
                   const bool             nontrivial_prox,
-                  const Prox&            prox) {
+                  const Prox&            prox) noexcept {
   for (unsigned f_ind = 0; f_ind < n_features; ++f_ind) {
     for (unsigned c_ind = 0; c_ind < n_classes; ++c_ind) {
       unsigned idx = f_ind*n_classes + c_ind;
@@ -355,7 +355,7 @@ void Saga(const Features&        x,
           unsigned&              n_iter,
           std::vector<unsigned>& return_codes,
           std::vector<double>&   losses,
-          const bool             debug) {
+          const bool             debug) noexcept {
 
   using namespace std;
 

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -283,7 +283,7 @@ Rcpp::List SgdnetDense(const Eigen::MatrixXd&     x,
 
 // [[Rcpp::export]]
 Rcpp::List SgdnetSparse(const Eigen::SparseMatrix<double>& x,
-                        std::vector<double>         y,
-                        const Rcpp::List&           control) {
+                        const std::vector<double>&         y,
+                        const Rcpp::List&                  control) {
   return SetupFamily(x, y, true, control);
 }

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -62,7 +62,8 @@
 //' regularization path using warm starts for successive iterations.
 //'
 //' @param x features
-//' @param response the model family
+//' @param y response
+//' @param family object of Family class
 //' @param is_sparse whether x is sparse or not
 //' @param control a list of control parameters
 //'

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -71,10 +71,11 @@
 //' @noRd
 //' @keywords internal
 template <typename T, typename Family>
-Rcpp::List SetupSgdnet(T                 x,
-                       Family&&          family,
-                       const bool        is_sparse,
-                       const Rcpp::List& control) {
+Rcpp::List SetupSgdnet(T                   x,
+                       std::vector<double> y,
+                       Family&&            family,
+                       const bool          is_sparse,
+                       const Rcpp::List&   control) {
   using namespace std;
   using namespace sgdnet;
 
@@ -82,8 +83,8 @@ Rcpp::List SetupSgdnet(T                 x,
   const double   elasticnet_mix   = Rcpp::as<double>(control["elasticnet_mix"]);
   vector<double> lambda           = Rcpp::as<vector<double>>(control["lambda"]);
   const unsigned n_lambda         = Rcpp::as<unsigned>(control["n_lambda"]);
-  const unsigned n_classes        = Rcpp::as<unsigned>(control["n_classes"]);
   const unsigned n_targets        = Rcpp::as<unsigned>(control["n_targets"]);
+  const unsigned n_classes        = Rcpp::as<unsigned>(control["n_classes"]);
   const double   lambda_min_ratio = Rcpp::as<double>(control["lambda_min_ratio"]);
   const bool     standardize      = Rcpp::as<bool>(control["standardize"]);
   const unsigned max_iter         = Rcpp::as<unsigned>(control["max_iter"]);
@@ -104,44 +105,53 @@ Rcpp::List SetupSgdnet(T                 x,
   AdaptiveTranspose(x);
 
   // Store null deviance here before processing response
-  double null_deviance = family.NullDeviance(fit_intercept);
+  double null_deviance = family.NullDeviance(y, fit_intercept, n_classes);
 
   // intercept updates are scaled to avoid oscillation
   double intercept_decay = is_sparse ? 0.01 : 1.0;
 
-  family.PreprocessResponse();
+  std::vector<double> y_center(n_classes, 0.0);
+  std::vector<double> y_scale(n_classes, 1.0);
+  family.Preprocess(y, y_center, y_scale);
 
   // Compute the lambda sequence
   vector<double> alpha, beta;
 
   RegularizationPath(lambda,
                      n_lambda,
+                     n_classes,
+                     n_samples,
                      lambda_min_ratio,
                      elasticnet_mix,
                      x,
+                     y,
+                     y_scale,
                      alpha,
                      beta,
                      family);
 
-  // Maximum of sums of squares over samples
-  double max_squared_sum = ColNormsMax(x);
-
-  vector<double> step_size =
-    family.StepSize(max_squared_sum, alpha, fit_intercept);
+  vector<double> step_size = StepSize(ColNormsMax(x),
+                                      alpha,
+                                      fit_intercept,
+                                      family.L_scaling,
+                                      n_samples);
 
   // Check if we need the nontrivial prox
   // TODO(jolars): allow more proximal operators
   sgdnet::SoftThreshold prox;
 
   // Setup intercept vector
+  vector<double> intercept(n_classes);
   vector<vector<double>> intercept_archive;
 
   // Setup weights matrix and weights archive
   vector<double> weights(n_features*n_classes);
   vector<vector<double>> weights_archive;
 
-  // Initialize gradient sum
+  // Initialize gradient trackers
+  vector<double> g_memory(n_samples*n_classes);
   vector<double> g_sum(n_features*n_classes);
+  vector<double> g_sum_intercept(n_classes);
 
   // Keep keep track of successes for each penalty
   vector<unsigned> return_codes;
@@ -153,7 +163,9 @@ Rcpp::List SetupSgdnet(T                 x,
   unsigned n_iter = 0;
 
   // Null deviance on scaled y for computing deviance ratio
-  double null_deviance_scaled = family.NullDeviance(fit_intercept);
+  double null_deviance_scaled = family.NullDeviance(y,
+                                                    fit_intercept,
+                                                    n_classes);
   vector<double> deviance_ratio;
   deviance_ratio.reserve(n_lambda);
 
@@ -162,6 +174,8 @@ Rcpp::List SetupSgdnet(T                 x,
     vector<double> losses;
 
     Saga(x,
+         y,
+         intercept,
          fit_intercept,
          intercept_decay,
          weights,
@@ -170,7 +184,9 @@ Rcpp::List SetupSgdnet(T                 x,
          step_size[lambda_ind],
          alpha[lambda_ind],
          beta[lambda_ind],
+         g_memory,
          g_sum,
+         g_sum_intercept,
          n_samples,
          n_features,
          n_classes,
@@ -182,23 +198,25 @@ Rcpp::List SetupSgdnet(T                 x,
          debug);
 
     double deviance = Deviance(x,
+                               y,
                                weights,
+                               intercept,
                                n_samples,
                                n_features,
                                n_classes,
                                family);
 
-    deviance_ratio.push_back(1.0 - deviance/null_deviance_scaled);
+    deviance_ratio.emplace_back(1.0 - deviance/null_deviance_scaled);
 
     // Rescale and store intercepts and weights for the current solution
     Rescale(weights,
             weights_archive,
-            family.intercept,
+            intercept,
             intercept_archive,
             x_center,
             x_scale,
-            family.y_center,
-            family.y_scale,
+            y_center,
+            y_scale,
             n_features,
             n_classes,
             fit_intercept);
@@ -231,18 +249,18 @@ Rcpp::List SetupFamily(const T&                   x,
 
   if (family_choice == "gaussian") {
 
-    sgdnet::Gaussian family(y, n_samples, n_classes);
-    return SetupSgdnet(x, std::move(family), is_sparse, control);
+    sgdnet::Gaussian family;
+    return SetupSgdnet(x, y, std::move(family), is_sparse, control);
 
   } else if (family_choice == "binomial") {
 
-    sgdnet::Binomial family(y, n_samples, n_classes);
-    return SetupSgdnet(x, std::move(family), is_sparse, control);
+    sgdnet::Binomial family;
+    return SetupSgdnet(x, y, std::move(family), is_sparse, control);
 
   } else if (family_choice == "multinomial") {
 
-    sgdnet::Multinomial family(y, n_samples, n_classes);
-    return SetupSgdnet(x, std::move(family), is_sparse, control);
+    sgdnet::Multinomial family;
+    return SetupSgdnet(x, y, std::move(family), is_sparse, control);
 
   } else {
 

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -134,21 +134,14 @@ Rcpp::List SetupSgdnet(T                 x,
   sgdnet::SoftThreshold prox;
 
   // Setup intercept vector
-  vector<double> intercept(n_classes);
   vector<vector<double>> intercept_archive;
 
   // Setup weights matrix and weights archive
   vector<double> weights(n_features*n_classes);
   vector<vector<double>> weights_archive;
 
-  // Sum of gradients for weights
-  vector<double> sum_gradient(n_features*n_classes);
-
-  // Gradient memory
-  vector<double> gradient_memory(n_samples*n_classes);
-
-  // Sum of gradients for intercept
-  vector<double> sum_gradient_intercept(n_classes);
+  // Initialize gradient sum
+  vector<double> g_sum(n_features*n_classes);
 
   // Keep keep track of successes for each penalty
   vector<unsigned> return_codes;
@@ -171,16 +164,13 @@ Rcpp::List SetupSgdnet(T                 x,
     Saga(x,
          fit_intercept,
          intercept_decay,
-         intercept,
          weights,
          family,
          prox,
          step_size[lambda_ind],
          alpha[lambda_ind],
          beta[lambda_ind],
-         sum_gradient,
-         sum_gradient_intercept,
-         gradient_memory,
+         g_sum,
          n_samples,
          n_features,
          n_classes,
@@ -193,7 +183,6 @@ Rcpp::List SetupSgdnet(T                 x,
 
     double deviance = Deviance(x,
                                weights,
-                               intercept,
                                n_samples,
                                n_features,
                                n_classes,
@@ -204,7 +193,7 @@ Rcpp::List SetupSgdnet(T                 x,
     // Rescale and store intercepts and weights for the current solution
     Rescale(weights,
             weights_archive,
-            intercept,
+            family.intercept,
             intercept_archive,
             x_center,
             x_scale,

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -62,7 +62,7 @@
 //' regularization path using warm starts for successive iterations.
 //'
 //' @param x features
-//' @param y response
+//' @param response the model family
 //' @param is_sparse whether x is sparse or not
 //' @param control a list of control parameters
 //'
@@ -71,7 +71,7 @@
 //' @noRd
 //' @keywords internal
 template <typename T, typename Family>
-Rcpp::List SetupSgdnet(T&&               x,
+Rcpp::List SetupSgdnet(T                 x,
                        Family&&          family,
                        const bool        is_sparse,
                        const Rcpp::List& control) {
@@ -231,10 +231,10 @@ Rcpp::List SetupSgdnet(T&&               x,
 }
 
 template <typename T>
-Rcpp::List SetupFamily(T&&                   x,
-                       std::vector<double>&& y,
-                       const bool            is_sparse,
-                       const Rcpp::List&     control) {
+Rcpp::List SetupFamily(const T&                   x,
+                       const std::vector<double>& y,
+                       const bool                 is_sparse,
+                       const Rcpp::List&          control) {
 
   auto family_choice = Rcpp::as<std::string>(control["family"]);
   auto n_classes = Rcpp::as<unsigned>(control["n_classes"]);
@@ -243,26 +243,17 @@ Rcpp::List SetupFamily(T&&                   x,
   if (family_choice == "gaussian") {
 
     sgdnet::Gaussian family(y, n_samples, n_classes);
-    return SetupSgdnet(std::forward<T>(x),
-                       std::move(family),
-                       is_sparse,
-                       control);
+    return SetupSgdnet(x, std::move(family), is_sparse, control);
 
   } else if (family_choice == "binomial") {
 
     sgdnet::Binomial family(y, n_samples, n_classes);
-    return SetupSgdnet(std::forward<T>(x),
-                       std::move(family),
-                       is_sparse,
-                       control);
+    return SetupSgdnet(x, std::move(family), is_sparse, control);
 
   } else if (family_choice == "multinomial") {
 
     sgdnet::Multinomial family(y, n_samples, n_classes);
-    return SetupSgdnet(std::forward<T>(x),
-                       std::move(family),
-                       is_sparse,
-                       control);
+    return SetupSgdnet(x, std::move(family), is_sparse, control);
 
   } else {
 
@@ -295,15 +286,15 @@ Rcpp::List SetupFamily(T&&                   x,
 //' @keywords internal
 //' @noRd
 // [[Rcpp::export]]
-Rcpp::List SgdnetDense(Eigen::MatrixXd     x,
-                       std::vector<double> y,
-                       const Rcpp::List&   control) {
-  return SetupFamily(std::move(x), std::move(y), false, control);
+Rcpp::List SgdnetDense(const Eigen::MatrixXd&     x,
+                       const std::vector<double>& y,
+                       const Rcpp::List&          control) {
+  return SetupFamily(x, y, false, control);
 }
 
 // [[Rcpp::export]]
-Rcpp::List SgdnetSparse(Eigen::SparseMatrix<double> x,
+Rcpp::List SgdnetSparse(const Eigen::SparseMatrix<double>& x,
                         std::vector<double>         y,
                         const Rcpp::List&           control) {
-  return SetupFamily(std::move(x), std::move(y), true, control);
+  return SetupFamily(x, y, true, control);
 }


### PR DESCRIPTION
The previous implementation of the `Family` class seemed to be detrimental for the speed of the algorithm. One of the reasons for this seems to have been its implementation as an abstract class. This pull request reimplements the class as a concrete class and uses templates instead of pointers to handle the various family implementations.

~~I have also modved the conditional means, gradient and intercept fitting inside the family function to avoid the zero-loops that the implementation currently imposes on univariate models (gaussian, binomial).~~

*Edit: I have now changed my mind and with <https://github.com/jolars/sgdnet/pull/15/commits/d208f644430a28c363cc9bdc396cb935f2c2b7b7> reverted to the old pattern of keeping the response vector, along with gradient and predictions, outside the family class. The performance difference is arguably negligible and makes the code, in general, much clearer and easier to maintain.*

There is still a downgrade in terms of performance compared to the implementation before the multinomial family was introduced, however, which I have not yet been able to fix. I'll keep working on it.

