### PR TITLE
Add observation weights

### DIFF
--- a/man/sgdnet.Rd
+++ b/man/sgdnet.Rd
@@ -8,9 +8,9 @@
 sgdnet(x, ...)
 
 \method{sgdnet}{default}(x, y, family = c("gaussian", "binomial",
-  "multinomial", "mgaussian"), alpha = 1, nlambda = 100,
-  lambda.min.ratio = if (NROW(x) < NCOL(x)) 0.01 else 1e-04,
-  lambda = NULL, maxit = 1000, standardize = TRUE,
+  "multinomial", "mgaussian"), weights = NULL, alpha = 1,
+  nlambda = 100, lambda.min.ratio = if (NROW(x) < NCOL(x)) 0.01 else
+  1e-04, lambda = NULL, maxit = 1000, standardize = TRUE,
   intercept = TRUE, thresh = 0.001, standardize.response = FALSE,
   cyclic = FALSE, batchsize = 1, ...)
 }
@@ -23,6 +23,8 @@ sgdnet(x, ...)
 
 \item{family}{reponse type, one of \code{'gaussian'}, \code{'binomial'},
 \code{'multinomial'}, or \code{'mgaussian'}. See \strong{Supported families} for details.}
+
+\item{weights}{observation weights}
 
 \item{alpha}{elastic net mixing parameter}
 

--- a/src/families.h
+++ b/src/families.h
@@ -44,8 +44,9 @@ public:
            Eigen::ArrayXXd&        gradient) const noexcept;
 
   double
-  NullDeviance(const Eigen::MatrixXd& y, // samples in rows
-               const bool             fit_intercept) const noexcept;
+  NullDeviance(const Eigen::MatrixXd&     y, // samples in rows
+               const bool                 fit_intercept,
+               const std::vector<double>& sample_weight) const noexcept;
 
   void
   FitNullModel(const Eigen::MatrixXd& y, // samples in rows
@@ -98,15 +99,16 @@ public:
   }
 
   double
-  NullDeviance(const Eigen::MatrixXd& y,
-               const bool             fit_intercept) const noexcept
+  NullDeviance(const Eigen::MatrixXd&     y,
+               const bool                 fit_intercept,
+               const std::vector<double>& sample_weight) const noexcept
   {
     Eigen::ArrayXd linear_predictor = Mean(y.transpose());
 
     double loss = 0.0;
     auto n = y.cols();
     for (decltype(n) i = 0; i < n; ++i)
-      loss += Loss(linear_predictor, y, i);
+      loss += sample_weight[i] * Loss(linear_predictor, y, i);
 
     return 2.0 * loss;
   }
@@ -172,8 +174,9 @@ public:
   }
 
   double
-  NullDeviance(const Eigen::MatrixXd& y,
-               const bool             fit_intercept) const noexcept
+  NullDeviance(const Eigen::MatrixXd&     y,
+               const bool                 fit_intercept,
+               const std::vector<double>& sample_weight) const noexcept
   {
     Eigen::ArrayXd linear_predictor(1);
 
@@ -186,7 +189,7 @@ public:
 
     double loss = 0.0;
     for (unsigned i = 0; i < y.cols(); ++i)
-      loss += Loss(linear_predictor, y, i);
+      loss += sample_weight[i] * Loss(linear_predictor, y, i);
 
     return 2.0 * loss;
   }
@@ -269,8 +272,9 @@ public:
   }
 
   double
-  NullDeviance(const Eigen::MatrixXd& y,
-               const bool             fit_intercept) const noexcept
+  NullDeviance(const Eigen::MatrixXd&     y,
+               const bool                 fit_intercept,
+               const std::vector<double>& sample_weight) const noexcept
   {
     Eigen::ArrayXd linear_predictor(n_classes);
 
@@ -287,7 +291,7 @@ public:
     auto loss = 0.0;
     for (decltype(y.cols()) i = 0; i < y.cols(); ++i) {
       auto c = static_cast<unsigned>(y(i) + 0.5);
-      loss += lse - linear_predictor[c];
+      loss += sample_weight[i] * (lse - linear_predictor[c]);
     }
 
     return 2.0 * loss;
@@ -376,14 +380,15 @@ public:
   }
 
   double
-  NullDeviance(const Eigen::MatrixXd& y,
-               const bool             fit_intercept) const noexcept
+  NullDeviance(const Eigen::MatrixXd&     y,
+               const bool                 fit_intercept,
+               const std::vector<double>& sample_weight) const noexcept
   {
     auto linear_predictor = Mean(y.transpose());
 
     double loss = 0.0;
     for (decltype(y.cols()) i = 0; i < y.cols(); ++i)
-      loss += Loss(linear_predictor, y, i);
+      loss += sample_weight[i] * Loss(linear_predictor, y, i);
 
     return 2.0 * loss;
   }

--- a/src/families.h
+++ b/src/families.h
@@ -38,11 +38,11 @@ public:
        const unsigned         i) const noexcept;
 
   void
-  Gradient(const Eigen::ArrayXXd& linear_predictor,
-           const Eigen::MatrixXd& y, // samples in columns
-           Eigen::ArrayXi&        ind,
-           const Eigen::VectorXd& weight,
-           Eigen::ArrayXXd&       gradient) const noexcept;
+  Gradient(const Eigen::ArrayXXd&  linear_predictor,
+           const Eigen::MatrixXd&  y, // samples in columns
+           Eigen::ArrayXi&         ind,
+           const Eigen::VectorXd&  weight,
+           Eigen::ArrayXXd&        gradient) const noexcept;
 
   double
   NullDeviance(const Eigen::MatrixXd& y, // samples in rows
@@ -90,11 +90,11 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd& linear_predictor,
-           const Eigen::MatrixXd& y,
-           Eigen::ArrayXi&        ind,
-           const Eigen::VectorXd& weight,
-           Eigen::ArrayXXd&       gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&  linear_predictor,
+           const Eigen::MatrixXd&  y,
+           Eigen::ArrayXi&         ind,
+           const Eigen::VectorXd&  weight,
+           Eigen::ArrayXXd&        gradient) const noexcept
   {
     for (int i = 0; i < ind.rows(); ++i) {
       gradient.col(i) = (linear_predictor(i) - y(ind(i)))*weight[ind(i)];
@@ -167,11 +167,11 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd& linear_predictor,
-           const Eigen::MatrixXd& y,
-           Eigen::ArrayXi&        ind,
-           const Eigen::VectorXd& weight,
-           Eigen::ArrayXXd&       gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&  linear_predictor,
+           const Eigen::MatrixXd&  y,
+           Eigen::ArrayXi&         ind,
+           const Eigen::VectorXd&  weight,
+           Eigen::ArrayXXd&        gradient) const noexcept
   {
     for (int i = 0; i < ind.rows(); ++i) {
       gradient.col(i) = (1.0 - y(ind(i)) - 1.0/(1.0 + std::exp(linear_predictor(i))))*weight[ind(i)];
@@ -255,11 +255,11 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd& linear_predictor,
-           const Eigen::MatrixXd& y,
-           Eigen::ArrayXi&        ind,
-           const Eigen::VectorXd& weight,
-           Eigen::ArrayXXd&       gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&  linear_predictor,
+           const Eigen::MatrixXd&  y,
+           Eigen::ArrayXi&         ind,
+           const Eigen::VectorXd&  weight,
+           Eigen::ArrayXXd&        gradient) const noexcept
   {
     unsigned p = linear_predictor.rows();
     Eigen::ArrayXd linear_predictor_col = Eigen::ArrayXd::Zero(p);
@@ -378,11 +378,11 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd& linear_predictor,
-           const Eigen::MatrixXd& y,
-           Eigen::ArrayXi&        ind,
-           const Eigen::VectorXd& weight,
-           Eigen::ArrayXXd&       gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&  linear_predictor,
+           const Eigen::MatrixXd&  y,
+           Eigen::ArrayXi&         ind,
+           const Eigen::VectorXd&  weight,
+           Eigen::ArrayXXd&        gradient) const noexcept
   {
     for (unsigned i = 0; i < ind.rows(); ++i) {
       gradient.col(i) = (linear_predictor.col(i) - y.col(ind(i)).array())*weight[ind(i)];

--- a/src/families.h
+++ b/src/families.h
@@ -38,10 +38,11 @@ public:
        const unsigned         i) const noexcept;
 
   void
-  Gradient(const Eigen::ArrayXXd&  linear_predictor,
-           const Eigen::MatrixXd&  y, // samples in columns
-           Eigen::ArrayXi&         ind,
-           Eigen::ArrayXXd&        gradient) const noexcept;
+  Gradient(const Eigen::ArrayXXd&     linear_predictor,
+           const Eigen::MatrixXd&     y, // samples in columns
+           Eigen::ArrayXi&            ind,
+           const std::vector<double>& sample_weight,
+           Eigen::ArrayXXd&           gradient) const noexcept;
 
   double
   NullDeviance(const Eigen::MatrixXd&     y, // samples in rows
@@ -88,13 +89,14 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd&  linear_predictor,
-           const Eigen::MatrixXd&  y,
-           Eigen::ArrayXi&         ind,
-           Eigen::ArrayXXd&        gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&     linear_predictor,
+           const Eigen::MatrixXd&     y,
+           Eigen::ArrayXi&            ind,
+           const std::vector<double>& sample_weight,
+           Eigen::ArrayXXd&           gradient) const noexcept
   {
     for (int i = 0; i < ind.rows(); ++i) {
-      gradient.col(i) = linear_predictor(i) - y(ind(i));
+      gradient.col(i) = (linear_predictor(i) - y(ind(i)))*sample_weight[ind(i)];
     }
   }
 
@@ -163,13 +165,14 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd&  linear_predictor,
-           const Eigen::MatrixXd&  y,
-           Eigen::ArrayXi&         ind,
-           Eigen::ArrayXXd&        gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&     linear_predictor,
+           const Eigen::MatrixXd&     y,
+           Eigen::ArrayXi&            ind,
+           const std::vector<double>& sample_weight,
+           Eigen::ArrayXXd&           gradient) const noexcept
   {
     for (int i = 0; i < ind.rows(); ++i) {
-      gradient.col(i) = 1.0 - y(ind(i)) - 1.0/(1.0 + std::exp(linear_predictor(i)));
+      gradient.col(i) = (1.0 - y(ind(i)) - 1.0/(1.0 + std::exp(linear_predictor(i))))*sample_weight[ind(i)];
     }
   }
 
@@ -249,10 +252,11 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd&  linear_predictor,
-           const Eigen::MatrixXd&  y,
-           Eigen::ArrayXi&         ind,
-           Eigen::ArrayXXd&        gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&     linear_predictor,
+           const Eigen::MatrixXd&     y,
+           Eigen::ArrayXi&            ind,
+           const std::vector<double>& sample_weight,
+           Eigen::ArrayXXd&           gradient) const noexcept
   {
     unsigned p = linear_predictor.rows();
     Eigen::ArrayXd linear_predictor_col = Eigen::ArrayXd::Zero(p);
@@ -268,6 +272,7 @@ public:
         if (j == c)
           gradient(j, i) -= 1.0;
       }
+      gradient.col(i) *= sample_weight[ind(i)];
     }
   }
 
@@ -369,13 +374,14 @@ public:
   }
 
   void
-  Gradient(const Eigen::ArrayXXd&  linear_predictor,
-           const Eigen::MatrixXd&  y,
-           Eigen::ArrayXi&         ind,
-           Eigen::ArrayXXd&        gradient) const noexcept
+  Gradient(const Eigen::ArrayXXd&     linear_predictor,
+           const Eigen::MatrixXd&     y,
+           Eigen::ArrayXi&            ind,
+           const std::vector<double>& sample_weight,
+           Eigen::ArrayXXd&           gradient) const noexcept
   {
     for (unsigned i = 0; i < ind.rows(); ++i) {
-      gradient.col(i) = linear_predictor.col(i) - y.col(ind(i)).array();
+      gradient.col(i) = (linear_predictor.col(i) - y.col(ind(i)).array())*sample_weight[ind(i)];
     }
   }
 

--- a/src/math.h
+++ b/src/math.h
@@ -185,14 +185,15 @@ template <typename T>
 inline
 Eigen::ArrayXd
 Proportions(const T&       y,
-            const unsigned n_classes)
+            const unsigned n_classes,
+            const Eigen::VectorXd& weight)
 {
   Eigen::ArrayXd proportions = Eigen::ArrayXd::Zero(n_classes);
   auto n = y.cols();
 
   for (decltype(n) i = 0; i < n; ++i) {
     auto c = static_cast<decltype(n)>(y(i) + 0.5);
-    proportions(c) += 1.0/n;
+    proportions(c) += weight[i]*1.0/n;
   }
 
   return proportions;

--- a/src/saga-dense.h
+++ b/src/saga-dense.h
@@ -100,33 +100,34 @@
 //'   `n_iter`, `return_codes`, and possibly `losses`.
 template <typename Family, typename Penalty>
 void
-Saga(Penalty&               penalty,
-     const Eigen::MatrixXd& x,
-     const Eigen::ArrayXd&  x_center_scaled,
-     const Eigen::MatrixXd& y,
-     Eigen::ArrayXd&        intercept,
-     const bool             fit_intercept,
-     const bool             is_sparse,
-     const bool             standardize,
-     Eigen::ArrayXXd&       w,
-     const Family&          family,
-     const double           gamma,
-     const double           alpha,
-     const double           beta,
-     Eigen::ArrayXXd&       g_memory,
-     Eigen::ArrayXXd&       g_sum,
-     Eigen::ArrayXd&        g_sum_intercept,
-     const unsigned         n_samples,
-     const unsigned         n_features,
-     const unsigned         n_classes,
-     const unsigned         max_iter,
-     const double           tol,
-     unsigned&              n_iter,
-     std::vector<unsigned>& return_codes,
-     std::vector<double>&   losses,
-     const bool             debug,
-     const bool             cyclic,
-     const unsigned         B) noexcept
+Saga(Penalty&                   penalty,
+     const Eigen::MatrixXd&     x,
+     const Eigen::ArrayXd&      x_center_scaled,
+     const std::vector<double>& sample_weight,
+     const Eigen::MatrixXd&     y,
+     Eigen::ArrayXd&            intercept,
+     const bool                 fit_intercept,
+     const bool                 is_sparse,
+     const bool                 standardize,
+     Eigen::ArrayXXd&           w,
+     const Family&              family,
+     const double               gamma,
+     const double               alpha,
+     const double               beta,
+     Eigen::ArrayXXd&           g_memory,
+     Eigen::ArrayXXd&           g_sum,
+     Eigen::ArrayXd&            g_sum_intercept,
+     const unsigned             n_samples,
+     const unsigned             n_features,
+     const unsigned             n_classes,
+     const unsigned             max_iter,
+     const double               tol,
+     unsigned&                  n_iter,
+     std::vector<unsigned>&     return_codes,
+     std::vector<double>&       losses,
+     const bool                 debug,
+     const bool                 cyclic,
+     const unsigned             B) noexcept
 {
   using namespace std;
 
@@ -179,6 +180,8 @@ Saga(Penalty&               penalty,
 
       family.Gradient(linear_predictor, y, s_ind, g);
 
+      SampleWeight(g, s_ind, sample_weight);
+
       g_change = g - SelectArray(g_memory, s_ind);
       SetCol(g_memory, g, s_ind);
 
@@ -228,7 +231,8 @@ Saga(Penalty&               penalty,
                               n_features,
                               n_classes,
                               is_sparse,
-                              standardize);
+                              standardize,
+                              sample_weight);
       losses.push_back(loss);
     }
 

--- a/src/saga-dense.h
+++ b/src/saga-dense.h
@@ -100,34 +100,34 @@
 //'   `n_iter`, `return_codes`, and possibly `losses`.
 template <typename Family, typename Penalty>
 void
-Saga(Penalty&                   penalty,
-     const Eigen::MatrixXd&     x,
-     const Eigen::ArrayXd&      x_center_scaled,
-     const std::vector<double>& sample_weight,
-     const Eigen::MatrixXd&     y,
-     Eigen::ArrayXd&            intercept,
-     const bool                 fit_intercept,
-     const bool                 is_sparse,
-     const bool                 standardize,
-     Eigen::ArrayXXd&           w,
-     const Family&              family,
-     const double               gamma,
-     const double               alpha,
-     const double               beta,
-     Eigen::ArrayXXd&           g_memory,
-     Eigen::ArrayXXd&           g_sum,
-     Eigen::ArrayXd&            g_sum_intercept,
-     const unsigned             n_samples,
-     const unsigned             n_features,
-     const unsigned             n_classes,
-     const unsigned             max_iter,
-     const double               tol,
-     unsigned&                  n_iter,
-     std::vector<unsigned>&     return_codes,
-     std::vector<double>&       losses,
-     const bool                 debug,
-     const bool                 cyclic,
-     const unsigned             B) noexcept
+Saga(Penalty&               penalty,
+     const Eigen::MatrixXd& x,
+     const Eigen::ArrayXd&  x_center_scaled,
+     const Eigen::VectorXd& weight,
+     const Eigen::MatrixXd& y,
+     Eigen::ArrayXd&        intercept,
+     const bool             fit_intercept,
+     const bool             is_sparse,
+     const bool             standardize,
+     Eigen::ArrayXXd&       w,
+     const Family&          family,
+     const double           gamma,
+     const double           alpha,
+     const double           beta,
+     Eigen::ArrayXXd&       g_memory,
+     Eigen::ArrayXXd&       g_sum,
+     Eigen::ArrayXd&        g_sum_intercept,
+     const unsigned         n_samples,
+     const unsigned         n_features,
+     const unsigned         n_classes,
+     const unsigned         max_iter,
+     const double           tol,
+     unsigned&              n_iter,
+     std::vector<unsigned>& return_codes,
+     std::vector<double>&   losses,
+     const bool             debug,
+     const bool             cyclic,
+     const unsigned         B) noexcept
 {
   using namespace std;
 
@@ -178,7 +178,7 @@ Saga(Penalty&                   penalty,
 
       linear_predictor = ((w.matrix() * subx).array()*wscale).colwise() + intercept;
 
-      family.Gradient(linear_predictor, y, s_ind, sample_weight, g);
+      family.Gradient(linear_predictor, y, s_ind, weight, g);
 
       g_change = g - SelectArray(g_memory, s_ind);
       SetCol(g_memory, g, s_ind);
@@ -230,7 +230,7 @@ Saga(Penalty&                   penalty,
                               n_classes,
                               is_sparse,
                               standardize,
-                              sample_weight);
+                              weight);
       losses.push_back(loss);
     }
 

--- a/src/saga-dense.h
+++ b/src/saga-dense.h
@@ -178,9 +178,7 @@ Saga(Penalty&                   penalty,
 
       linear_predictor = ((w.matrix() * subx).array()*wscale).colwise() + intercept;
 
-      family.Gradient(linear_predictor, y, s_ind, g);
-
-      SampleWeight(g, s_ind, sample_weight);
+      family.Gradient(linear_predictor, y, s_ind, sample_weight, g);
 
       g_change = g - SelectArray(g_memory, s_ind);
       SetCol(g_memory, g, s_ind);

--- a/src/saga-sparse.h
+++ b/src/saga-sparse.h
@@ -205,7 +205,7 @@ void
 Saga(Penalty&                           penalty,
      const Eigen::SparseMatrix<double>& x,
      const Eigen::ArrayXd&              x_center_scaled,
-     const std::vector<double>&         sample_weight,
+     const Eigen::VectorXd&             weight,
      const Eigen::MatrixXd&             y,
      Eigen::ArrayXd&                    intercept,
      const bool                         fit_intercept,
@@ -304,7 +304,7 @@ Saga(Penalty&                           penalty,
       if (standardize)
         linear_predictor -= (w.matrix() * x_center_scaled.matrix()).array()*wscale;
 
-      family.Gradient(linear_predictor, y, s_ind, sample_weight, g);
+      family.Gradient(linear_predictor, y, s_ind, weight, g);
 
       g_change = g - SelectArray(g_memory, s_ind);
       SetCol(g_memory, g, s_ind);
@@ -388,7 +388,7 @@ Saga(Penalty&                           penalty,
                               n_classes,
                               is_sparse,
                               standardize,
-                              sample_weight);
+                              weight);
       losses.push_back(loss);
     }
 

--- a/src/saga-sparse.h
+++ b/src/saga-sparse.h
@@ -304,9 +304,7 @@ Saga(Penalty&                           penalty,
       if (standardize)
         linear_predictor -= (w.matrix() * x_center_scaled.matrix()).array()*wscale;
 
-      family.Gradient(linear_predictor, y, s_ind, g);
-
-      SampleWeight(g, s_ind, sample_weight);
+      family.Gradient(linear_predictor, y, s_ind, sample_weight, g);
 
       g_change = g - SelectArray(g_memory, s_ind);
       SetCol(g_memory, g, s_ind);

--- a/src/saga-sparse.h
+++ b/src/saga-sparse.h
@@ -205,6 +205,7 @@ void
 Saga(Penalty&                           penalty,
      const Eigen::SparseMatrix<double>& x,
      const Eigen::ArrayXd&              x_center_scaled,
+     const std::vector<double>&         sample_weight,
      const Eigen::MatrixXd&             y,
      Eigen::ArrayXd&                    intercept,
      const bool                         fit_intercept,
@@ -305,6 +306,8 @@ Saga(Penalty&                           penalty,
 
       family.Gradient(linear_predictor, y, s_ind, g);
 
+      SampleWeight(g, s_ind, sample_weight);
+
       g_change = g - SelectArray(g_memory, s_ind);
       SetCol(g_memory, g, s_ind);
 
@@ -386,7 +389,8 @@ Saga(Penalty&                           penalty,
                               n_features,
                               n_classes,
                               is_sparse,
-                              standardize);
+                              standardize,
+                              sample_weight);
       losses.push_back(loss);
     }
 

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -174,13 +174,14 @@ SetupSgdnet(T                 x,
                      y_scale,
                      alpha,
                      beta,
-                     family);
+                     family,
+                     weight);
 
   // Transpose for more efficient access of samples
   AdaptiveTranspose(x);
   AdaptiveTranspose(y);
 
-  auto step_size = StepSize(ColNormsMax(x, x_center_scaled, standardize),
+  auto step_size = StepSize(ColNormsMax(x, x_center_scaled, standardize, weight),
                             alpha,
                             fit_intercept,
                             family.L_scaling,

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -138,6 +138,7 @@ SetupSgdnet(T                 x,
   const bool     debug            = Rcpp::as<bool>(control["debug"]);
   const bool     cyclic           = Rcpp::as<bool>(control["cyclic"]);
   const unsigned B                = Rcpp::as<unsigned>(control["batch_size"]);
+  const vector<double> sample_weight = Rcpp::as<vector<double>>(control["sample_weight"]);
 
   auto n_samples  = x.rows();
   auto n_features = x.cols();
@@ -153,7 +154,7 @@ SetupSgdnet(T                 x,
                                              : Eigen::ArrayXd::Zero(n_features);
 
   // Store null deviance here before processing response
-  double null_deviance = family.NullDeviance(y.transpose(), fit_intercept);
+  double null_deviance = family.NullDeviance(y.transpose(), fit_intercept, sample_weight);
 
   Eigen::ArrayXd y_center = Eigen::ArrayXd::Zero(n_classes);
   Eigen::ArrayXd y_scale  = Eigen::ArrayXd::Ones(n_classes);
@@ -210,7 +211,7 @@ SetupSgdnet(T                 x,
 
   // Null deviance on scaled y for computing deviance ratio
   family.FitNullModel(y, fit_intercept, intercept);
-  double null_deviance_scaled = family.NullDeviance(y, fit_intercept);
+  double null_deviance_scaled = family.NullDeviance(y, fit_intercept, sample_weight);
 
   vector<double> deviance_ratio;
   deviance_ratio.reserve(n_lambda);
@@ -222,6 +223,7 @@ SetupSgdnet(T                 x,
     RunSaga(control,
             x,
             x_center_scaled,
+            sample_weight,
             y,
             intercept,
             fit_intercept,
@@ -257,7 +259,8 @@ SetupSgdnet(T                 x,
                                n_classes,
                                family,
                                is_sparse,
-                               standardize);
+                               standardize,
+                               sample_weight);
 
     deviance_ratio.emplace_back(1.0 - deviance/null_deviance_scaled);
 

--- a/src/sgdnet.cpp
+++ b/src/sgdnet.cpp
@@ -138,7 +138,7 @@ SetupSgdnet(T                 x,
   const bool     debug            = Rcpp::as<bool>(control["debug"]);
   const bool     cyclic           = Rcpp::as<bool>(control["cyclic"]);
   const unsigned B                = Rcpp::as<unsigned>(control["batch_size"]);
-  const vector<double> sample_weight = Rcpp::as<vector<double>>(control["sample_weight"]);
+  const Eigen::VectorXd weight    = Rcpp::as<Eigen::Map<Eigen::VectorXd>>(control["sample_weight"]);
 
   auto n_samples  = x.rows();
   auto n_features = x.cols();
@@ -154,7 +154,7 @@ SetupSgdnet(T                 x,
                                              : Eigen::ArrayXd::Zero(n_features);
 
   // Store null deviance here before processing response
-  double null_deviance = family.NullDeviance(y.transpose(), fit_intercept, sample_weight);
+  double null_deviance = family.NullDeviance(y.transpose(), fit_intercept, weight);
 
   Eigen::ArrayXd y_center = Eigen::ArrayXd::Zero(n_classes);
   Eigen::ArrayXd y_scale  = Eigen::ArrayXd::Ones(n_classes);
@@ -210,8 +210,8 @@ SetupSgdnet(T                 x,
   unsigned n_iter = 0;
 
   // Null deviance on scaled y for computing deviance ratio
-  family.FitNullModel(y, fit_intercept, intercept);
-  double null_deviance_scaled = family.NullDeviance(y, fit_intercept, sample_weight);
+  family.FitNullModel(y, fit_intercept, intercept, weight);
+  double null_deviance_scaled = family.NullDeviance(y, fit_intercept, weight);
 
   vector<double> deviance_ratio;
   deviance_ratio.reserve(n_lambda);
@@ -223,7 +223,7 @@ SetupSgdnet(T                 x,
     RunSaga(control,
             x,
             x_center_scaled,
-            sample_weight,
+            weight,
             y,
             intercept,
             fit_intercept,
@@ -260,7 +260,7 @@ SetupSgdnet(T                 x,
                                family,
                                is_sparse,
                                standardize,
-                               sample_weight);
+                               weight);
 
     deviance_ratio.emplace_back(1.0 - deviance/null_deviance_scaled);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -547,20 +547,5 @@ WeightStep(Eigen::ArrayXXd& g_change,
   return step;
 }
 
-//' Add observation weights to gradient
-//'
-//' @param g gradient of selected samples to be weighted
-//' @param ind index array of selected columns
-//' @param sample_weight observation weights
-void
-SampleWeight(Eigen::ArrayXXd&           g,
-             Eigen::ArrayXi&            ind,
-             const std::vector<double>& sample_weight)
-{
-  for (unsigned i = 0; i < ind.rows(); ++i) {
-    g.col(i) *= sample_weight[ind(i)];
-  }
-}
-
 #endif // SGDNET_UTILS_
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -192,27 +192,27 @@ RegularizationPath(std::vector<double>&   lambda,
 //' @param n_samples number of samples
 //' @param n_features number of features
 //' @param n_classes number of pseudo-classes
-//' @param sample_weight observation weights
+//' @param weight observation weights
 //'
 //' @return The loss of the current epoch is appended to `losses`.
 //'
 //' @noRd
 template <typename T, typename Family>
 double
-EpochLoss(const T&                   x,
-          const Eigen::ArrayXd&      x_center_scaled,
-          const Eigen::MatrixXd&     y,
-          const Eigen::ArrayXXd&     w,
-          const Eigen::ArrayXd&      intercept,
-          const Family&              family,
-          const double               alpha,
-          const double               beta,
-          const unsigned             n_samples,
-          const unsigned             n_features,
-          const unsigned             n_classes,
-          const bool                 is_sparse,
-          const bool                 standardize,
-          const std::vector<double>& sample_weight)
+EpochLoss(const T&               x,
+          const Eigen::ArrayXd&  x_center_scaled,
+          const Eigen::MatrixXd& y,
+          const Eigen::ArrayXXd& w,
+          const Eigen::ArrayXd&  intercept,
+          const Family&          family,
+          const double           alpha,
+          const double           beta,
+          const unsigned         n_samples,
+          const unsigned         n_features,
+          const unsigned         n_classes,
+          const bool             is_sparse,
+          const bool             standardize,
+          const Eigen::VectorXd& weight)
 {
   Eigen::ArrayXd linear_predictor(n_classes);
 
@@ -222,7 +222,7 @@ EpochLoss(const T&                   x,
     linear_predictor = (w.matrix() * x.col(s_ind)).array() + intercept;
     if (standardize && is_sparse)
       linear_predictor -= (w.matrix() * x_center_scaled.matrix()).array();
-    loss += sample_weight[s_ind] * family.Loss(linear_predictor, y, s_ind)/n_samples;
+    loss += weight[s_ind] * family.Loss(linear_predictor, y, s_ind)/n_samples;
   }
 
   return loss;
@@ -301,23 +301,23 @@ AdaptiveTranspose(Eigen::MatrixXd& x)
 //' @param n_feature the number of features
 //' @param n_classes the number of classes
 //' @param family a pointer to the family object
-//' @param sample_weight observation weights
+//' @param weight observation weights
 //'
 //' @return Returns the deviance.
 template <typename T, typename Family>
 double
-Deviance(const T&                   x,
-         const Eigen::ArrayXd&      x_center_scaled,
-         const Eigen::MatrixXd&     y,
-         const Eigen::ArrayXXd&     w,
-         const Eigen::ArrayXd&      intercept,
-         const unsigned             n_samples,
-         const unsigned             n_features,
-         const unsigned             n_classes,
-         const Family&              family,
-         const bool                 is_sparse,
-         const bool                 standardize,
-         const std::vector<double>& sample_weight)
+Deviance(const T&               x,
+         const Eigen::ArrayXd&  x_center_scaled,
+         const Eigen::MatrixXd& y,
+         const Eigen::ArrayXXd& w,
+         const Eigen::ArrayXd&  intercept,
+         const unsigned         n_samples,
+         const unsigned         n_features,
+         const unsigned         n_classes,
+         const Family&          family,
+         const bool             is_sparse,
+         const bool             standardize,
+         const Eigen::VectorXd& weight)
 {
   double loss = 0.0;
   Eigen::ArrayXd linear_predictor(n_classes);
@@ -326,7 +326,7 @@ Deviance(const T&                   x,
     linear_predictor = (w.matrix() * x.col(s_ind)).array() + intercept;
     if (standardize && is_sparse)
       linear_predictor -= (w.matrix() * x_center_scaled.matrix()).array();
-    loss += sample_weight[s_ind] * family.Loss(linear_predictor, y, s_ind);
+    loss += weight[s_ind] * family.Loss(linear_predictor, y, s_ind);
   }
 
   return 2.0 * loss;

--- a/src/utils.h
+++ b/src/utils.h
@@ -192,25 +192,27 @@ RegularizationPath(std::vector<double>&   lambda,
 //' @param n_samples number of samples
 //' @param n_features number of features
 //' @param n_classes number of pseudo-classes
+//' @param sample_weight observation weights
 //'
 //' @return The loss of the current epoch is appended to `losses`.
 //'
 //' @noRd
 template <typename T, typename Family>
 double
-EpochLoss(const T&               x,
-          const Eigen::ArrayXd&  x_center_scaled,
-          const Eigen::MatrixXd& y,
-          const Eigen::ArrayXXd& w,
-          const Eigen::ArrayXd&  intercept,
-          const Family&          family,
-          const double           alpha,
-          const double           beta,
-          const unsigned         n_samples,
-          const unsigned         n_features,
-          const unsigned         n_classes,
-          const bool             is_sparse,
-          const bool             standardize)
+EpochLoss(const T&                   x,
+          const Eigen::ArrayXd&      x_center_scaled,
+          const Eigen::MatrixXd&     y,
+          const Eigen::ArrayXXd&     w,
+          const Eigen::ArrayXd&      intercept,
+          const Family&              family,
+          const double               alpha,
+          const double               beta,
+          const unsigned             n_samples,
+          const unsigned             n_features,
+          const unsigned             n_classes,
+          const bool                 is_sparse,
+          const bool                 standardize,
+          const std::vector<double>& sample_weight)
 {
   Eigen::ArrayXd linear_predictor(n_classes);
 
@@ -220,7 +222,7 @@ EpochLoss(const T&               x,
     linear_predictor = (w.matrix() * x.col(s_ind)).array() + intercept;
     if (standardize && is_sparse)
       linear_predictor -= (w.matrix() * x_center_scaled.matrix()).array();
-    loss += family.Loss(linear_predictor, y, s_ind)/n_samples;
+    loss += sample_weight[s_ind] * family.Loss(linear_predictor, y, s_ind)/n_samples;
   }
 
   return loss;
@@ -299,21 +301,23 @@ AdaptiveTranspose(Eigen::MatrixXd& x)
 //' @param n_feature the number of features
 //' @param n_classes the number of classes
 //' @param family a pointer to the family object
+//' @param sample_weight observation weights
 //'
 //' @return Returns the deviance.
 template <typename T, typename Family>
 double
-Deviance(const T&               x,
-         const Eigen::ArrayXd&  x_center_scaled,
-         const Eigen::MatrixXd& y,
-         const Eigen::ArrayXXd& w,
-         const Eigen::ArrayXd&  intercept,
-         const unsigned         n_samples,
-         const unsigned         n_features,
-         const unsigned         n_classes,
-         const Family&          family,
-         const bool             is_sparse,
-         const bool             standardize)
+Deviance(const T&                   x,
+         const Eigen::ArrayXd&      x_center_scaled,
+         const Eigen::MatrixXd&     y,
+         const Eigen::ArrayXXd&     w,
+         const Eigen::ArrayXd&      intercept,
+         const unsigned             n_samples,
+         const unsigned             n_features,
+         const unsigned             n_classes,
+         const Family&              family,
+         const bool                 is_sparse,
+         const bool                 standardize,
+         const std::vector<double>& sample_weight)
 {
   double loss = 0.0;
   Eigen::ArrayXd linear_predictor(n_classes);
@@ -322,7 +326,7 @@ Deviance(const T&               x,
     linear_predictor = (w.matrix() * x.col(s_ind)).array() + intercept;
     if (standardize && is_sparse)
       linear_predictor -= (w.matrix() * x_center_scaled.matrix()).array();
-    loss += family.Loss(linear_predictor, y, s_ind);
+    loss += sample_weight[s_ind] * family.Loss(linear_predictor, y, s_ind);
   }
 
   return 2.0 * loss;
@@ -541,6 +545,21 @@ WeightStep(Eigen::ArrayXXd& g_change,
     step += g_change_col.rowwise()*subx.col(i).transpose().array();
   }
   return step;
+}
+
+//' Add observation weights to gradient
+//'
+//' @param g gradient of selected samples to be weighted
+//' @param ind index array of selected columns
+//' @param sample_weight observation weights
+void
+SampleWeight(Eigen::ArrayXXd&           g,
+             Eigen::ArrayXi&            ind,
+             const std::vector<double>& sample_weight)
+{
+  for (unsigned i = 0; i < ind.rows(); ++i) {
+    g.col(i) *= sample_weight[ind(i)];
+  }
 }
 
 #endif // SGDNET_UTILS_

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -149,7 +149,7 @@ test_that("compare solution with glmnet using sample weights", {
       intercept = grid$intercept[i],
       alpha = grid$alpha[i],
       lambda = 0.0001,
-      thresh = 1e-7,
+      thresh = 1e-9,
       maxit = 1000
     )
 
@@ -173,3 +173,4 @@ test_that("compare solution with glmnet using sample weights", {
     }
   }
 })
+

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -160,7 +160,7 @@ test_that("compare solution with glmnet using sample weights", {
 
     pars$y <- d$y
     pars$x <- x
-    pars$weights <- c(rep(0.5, 250), rep(1.5, 250))
+    pars$weights <- c(0.5, 1.5, rep(1, n-2))
 
     sfit <- do.call(sgdnet, pars)
     gfit <- do.call(glmnet, pars)

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -1,0 +1,130 @@
+test_that("we receive the correct deviance from deviance.sgdnet() with sample weight", {
+  set.seed(1)
+
+  library(glmnet)
+  glmnet.control(fdev = 0)
+
+  d <- 2
+  n <- 100
+  x <- matrix(rnorm(n*d), nrow = n, ncol = d)
+
+  loglink <- function(x) {
+    pmin <- 1e-9
+    pmax <- 1 - pmin
+    x <- ifelse(x < pmin, pmin, x)
+    x <- ifelse(x > pmax, pmax, x)
+    log(x / (1 - x))
+  }
+
+  gaussian_nulldev <- function(y, weights) {
+    no <- length(y)
+    y_center <- (y - weighted.mean(y, weights))^2
+
+    loss <- 0
+    for (i in 1:no) {
+      loss <- loss + y_center[i]*weights[i]
+    }
+    loss
+  }
+
+  binomial_nulldev <- function(y, intercept = FALSE, weights) {
+    no <- length(y)
+
+    if (intercept){
+      p <- loglink(weighted.mean(y, weights))
+    } else {
+      p <- 0 
+    }
+
+    loss <- 0
+    for (i in 1:no) {
+      loss <- loss- (y[i]*p - log(1 + exp(p)))*weights[i]
+    }
+    2*loss
+  }
+
+  multinomial_nulldev <- function(y, intercept = FALSE, weights) {
+    no <- length(y)
+    nc <- length(unique(y))
+
+    if (intercept) {
+      pred <- rep(0, nc)
+      for (i in 1:no) {
+        pred[y[i]+1] = pred[y[i]+1] + weights[i]/no
+      }
+
+    } else {
+      pred <- rep(1, nc)/nc
+    }
+
+    pred2 <- log(pred) - sum(log(pred))/nc
+
+    loss <- 0
+    for (i in seq_len(no)) {
+      loss <- loss + (log(sum(exp(pred2))) - pred2[y[i] + 1])*weights[i]
+    }
+
+    2*loss
+  }
+
+  mgaussian_nulldev <- function(y, weights) {
+    no <- nrow(y)
+    nc <- ncol(y)
+
+    col_mean <- rep(0, nc)
+    for (i in 1:nc) {
+      col_mean[i] <- weighted.mean(y[,i], weights)
+    }
+
+    y_center <- t(y) - col_mean
+
+    loss <- 0
+    for (i in 1:no) {
+      loss <- loss + sum(y_center[,i]^2)*weights[i]
+    }
+    loss
+  }
+  grid <- expand.grid(
+    family = c("gaussian", "binomial", "multinomial", "mgaussian"),
+    intercept = c(TRUE, FALSE),
+    alpha = c(0, 0.5, 1),
+    standardize = c(TRUE, FALSE),
+    stringsAsFactors = FALSE
+  )
+
+  for (i in seq_len(nrow(grid))) {
+    pars <- list(
+      x = x,
+      standardize = grid$standardize[i],
+      family = grid$family[i],
+      intercept = grid$intercept[i],
+      alpha = grid$alpha[i],
+      thresh = 0.1,
+      lambda = 1/nrow(x),
+      weights = c(0.5, 1.5, 0.5, 1.5, rep(1, nrow(x)-4))
+    )
+
+    y <- switch(pars$family,
+                gaussian = rnorm(n, 10, 2),
+                binomial = rbinom(n, 1, 0.8),
+                multinomial = rbinom(n, 2, 0.5),
+                mgaussian = cbind(rnorm(n, 100), rnorm(n)))
+    pars$y <- y
+    intercept <- pars$intercept
+
+    # compute null deviance manually
+    nulldev <- switch(
+      pars$family,
+      gaussian = gaussian_nulldev(y, weights = weights),
+      binomial = binomial_nulldev(y, intercept = intercept, weights = weights),
+      multinomial = multinomial_nulldev(y, intercept = intercept, weights = weights),
+      mgaussian = mgaussian_nulldev(y, weights = weights)
+    )
+
+    sfit <- do.call(sgdnet, pars)
+    gfit <- do.call(glmnet, pars)
+
+    expect_equal(sfit$nulldev, gfit$nulldev, tolerance = 1e-6)
+    expect_equal(sfit$nulldev, nulldev)
+  }
+})


### PR DESCRIPTION
Hi mentors, this PR implements observation weights. The changes I am making are multiplying sample weights to gradient, loss and changing to weighted mean in null model, as well as add weight when computing maximum column norm for step size and largest lambda. It seems that glmnet's largest lambda is different.